### PR TITLE
allow user to specify which node should store cache entries

### DIFF
--- a/lib/irmin_arp.mli
+++ b/lib/irmin_arp.mli
@@ -19,6 +19,6 @@ module Arp : sig
       (Maker : Irmin.S_MAKER) :
   sig
     include V1_LWT.ARP
-    val connect : Ethif.t -> Irmin.config -> [> `Ok of t | `Error of error ] io
+    val connect : Ethif.t -> Irmin.config -> string list -> [> `Ok of t | `Error of error ] io
   end
 end

--- a/lib/table.mli
+++ b/lib/table.mli
@@ -3,7 +3,7 @@ module Make(P: Irmin.Path.S) : sig
   module Ops : sig
     include Tc.S0 with type t = Entry.t M.t (* map from ip -> entry *)
   end
-  include Irmin.Contents.S
+  include Irmin.Contents.S with module Path = P
   val to_map : t -> Entry.t M.t
   val of_map : Entry.t M.t -> t
   val add : Key.t -> Entry.t -> t -> t

--- a/lib_test/common.ml
+++ b/lib_test/common.ml
@@ -15,9 +15,8 @@ let or_error name fn t =
   | `Error e -> OUnit.assert_failure ("Error starting " ^ name)
   | `Ok t -> return t
 
-let clear_cache config =
+let clear_cache config node =
   let store = Irmin.basic (module Irmin_backend_fs) (module T) in
   Irmin.create store config Irmin_unix.task >>= fun store ->
-  let node = T.Path.empty in
-  Irmin.remove (store "removing previous history for new test run") node
+  Irmin.remove (store "removing previous history for new test run") [node]
 


### PR DESCRIPTION
Previously we just assumed that all caches should be at T.Path.empty, which was often suboptimal (read: broken).
